### PR TITLE
Disabled the MDR_* environment variables

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,7 @@ WORKDIR /usr/share/nginx/html
 ### Copy subfolder of dist as ng buils --prod creates an extra subfolder
 COPY --from=build /build/dist/sample-locator .
 COPY docker/config                  ./config
+COPY src/config/env.js              ./config/env.js
 
 ADD docker/start.sh                 /samply/
 RUN chmod +x                        /samply/start.sh

--- a/docker/start.sh
+++ b/docker/start.sh
@@ -1,6 +1,12 @@
 #!/usr/bin/env bash
 
-envsubst  < ./config/env.template.js > ./config/env.js
+# Substitute the env vars from the docker-compose.yml files into the
+# template and overwite the stock env.js file.
+# Ideally, this would be conditional on the existence of the
+# variables, but right now, if they are not defined, then
+# env.js gets filled with emptiness and you get a blank GUI.
+#envsubst  < ./config/env.template.js > ./config/env.js
+
 envsubst  < ./config/auth.clientConfiguration.template.json > ./config/auth.clientConfiguration.json
 
 echo 'Start NGINX in foreground (non-daemon-mode)'


### PR DESCRIPTION
These variables are used to define the content of the GUI.

Due to the way that the scripts have been written for Docker, the
env.json file is completely overwritten, so that the things you
define there are ignored, even if you don't define any of the
MDR_* variables.

By commenting out the offending lines, I have re-enabled the
env.json file, but the MDR_* environment variables no longer
have an effect. This allows Thomas' changes to work.

And defining the GUI in the docker-compose.yml file seems rather
ugly.