### PR TITLE
Eliminate dependency on mdr16 namespace

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sample-locator",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",

--- a/src/app/service/mdr-field-provider.service.ts
+++ b/src/app/service/mdr-field-provider.service.ts
@@ -49,4 +49,8 @@ export class MdrFieldProviderService {
   public getPossibleField(urn: string): ExtendedMdrFieldDto | null {
     return this.slStorageService.getAllDataElments().find(field => field.urn === urn);
   }
+
+  public getMdrConfigService(): MdrConfigService | null {
+    return this.mdrConfigService;
+  }
 }

--- a/src/app/service/query-provider.service.ts
+++ b/src/app/service/query-provider.service.ts
@@ -9,7 +9,7 @@ import {SlStorageService} from './sl-storage.service';
 })
 export class QueryProviderService {
 
-  private static URN_DIAGNOSIS = 'urn:mdr16:dataelement:27:1';
+  private static ID_DIAGNOSIS = '27';
   private static TYPE_DIAGNOSIS = MdrDataType.STRING;
 
   public query: EssentialQueryDto;
@@ -35,7 +35,7 @@ export class QueryProviderService {
       fieldDtos: []
     };
 
-    this.addField(QueryProviderService.URN_DIAGNOSIS, QueryProviderService.TYPE_DIAGNOSIS);
+    this.addField(this.getUrnDiagnosis(), QueryProviderService.TYPE_DIAGNOSIS);
 
     this.slStorageService.setNToken('');
     this.slStorageService.setQuery(this.query);
@@ -94,5 +94,17 @@ export class QueryProviderService {
       default:
         return null;
     }
+  }
+  private getUrnDiagnosis(): string | null {
+    var urnDiagnosis = null;
+    for (const dataElement of this.mdrFieldProviderService.getMdrConfigService().getMdrConfig().dataElements) {
+      var urnParts = dataElement.urn.split(':');
+      if (urnParts.length === 5 && urnParts[3] != null && urnParts[3] === QueryProviderService.ID_DIAGNOSIS) {
+        urnDiagnosis = dataElement.urn;
+        break;
+      }
+    }
+
+    return urnDiagnosis
   }
 }


### PR DESCRIPTION
When the Sample Locator GUI opens, it provides by default a field
for entering ICD10 diagnosis codes.

To achieve this, the URN for diagnosis was hard-coded to be:

urn:mdr16:dataelement:27:1

This makes the code inflexible, because it only works for the mdr16
namespace.

The patch being submitted here solves this by looking for the ID '27'
in all of the URNs known to the MDR namespace being used, and using
the corresponding URN for diagnosis if found.

This is still not completely generic of course, it still depends on MDR
developers retaining the ID '27' for diagnosis. However, it works for
the two namespaces being used in GBA and BBMRI, namely mdr16 and
bbmri-1-2, see:

https://locator.bbmri-eric.eu/v3/api/mdr/dataelements/urn:mdr16:dataelement:27:1
https://locator.bbmri-eric.eu/v3/api/mdr/dataelements/urn:bbmri-1-2:dataelement:27:1

Note: the Node.js version had to be nailed to 15, otherwise the code
would not compile.

**What's in the PR**
* ...

**How to test manually**
* ...
