### PR TITLE
Activate the "Send" button when the branding UI is "GBA".

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sample-locator",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",

--- a/src/app/page/search/search.component.html
+++ b/src/app/page/search/search.component.html
@@ -26,7 +26,8 @@
                                [visible]="showTopActionButtons()"></app-samply-button>
             <div *ngIf="featureService.brandingUI() === 'GBA'">
               <app-samply-button [imageIcon]="faPaperPlane" [active]="true" label="Send"
-                                 [visible]="showTopActionButtons()"></app-samply-button>
+                                 [visible]="showTopActionButtons()"
+				 (click)="sendQuery()"></app-samply-button>
             </div>
             <div *ngIf="featureService.brandingUI() === 'BBMRI'">
               <div *ngIf="!userService.getLoginValid()">
@@ -56,7 +57,8 @@
                                (click)="resetQuery()"></app-samply-button>
             <app-samply-button [imageIcon]="faEdit" [active]="false" label="Edit"></app-samply-button>
             <div *ngIf="featureService.brandingUI() === 'GBA'">
-              <app-samply-button [imageIcon]="faPaperPlane" [active]="false" label="Send"></app-samply-button>
+              <app-samply-button [imageIcon]="faPaperPlane" [active]="true" label="Send"
+		                 (click)="sendQuery()"></app-samply-button>
             </div>
             <div *ngIf="featureService.brandingUI() === 'BBMRI'">
               <div *ngIf="!userService.getLoginValid()">


### PR DESCRIPTION
Original situation: if the branding UI was "GBA", the "Send" button
was grayed out and inactive. It was not possible to run a search.

This patch enables the button and also sends the query for execution.

The functionality with branding UI "BBMRI" was left unchanged, since
this is working correctly.

**What's in the PR**
* ...

**How to test manually**
* ...
