### PR TITLE
Footer logos depend on branding (GBA or BBMRI)

### DIFF
--- a/src/app/component/footer/footer.component.html
+++ b/src/app/component/footer/footer.component.html
@@ -23,9 +23,6 @@
 
   <div fxLayout="row" fxLayoutAlign="space-between center" class="footer-logos">
     <div fxLayout="row" fxLayoutAlign="space-between center">
-      <a *ngIf="featureService.brandingUI() === 'BBMRI'" href="https://www.bbmri.de/" title="BBMRI" target="_blank">
-        <img src="assets/img/GBN_CMYK_schwarz.svg" alt="GBN-LOGO" class="gba-logo"/>
-      </a>
       <a *ngIf="featureService.brandingUI() === 'GBA'" href="https://www.dkfz.de/en/verbis/" title="DKFZ" target="_blank">
         <img src="assets/img/german-cancer-research-center-dkfz-logo-vector.svg#svgView(viewBox(240, 180, 180, 300))" alt="DKFZ-LOGO" class="dkfz-logo"/>
       </a>

--- a/src/app/component/footer/footer.component.html
+++ b/src/app/component/footer/footer.component.html
@@ -26,7 +26,7 @@
       <a *ngIf="featureService.brandingUI() === 'BBMRI'" href="https://www.bbmri.de/" title="BBMRI" target="_blank">
         <img src="assets/img/GBN_CMYK_schwarz.svg" alt="GBN-LOGO" class="gba-logo"/>
       </a>
-      <a href="https://www.dkfz.de/en/verbis/" title="DKFZ" target="_blank">
+      <a *ngIf="featureService.brandingUI() === 'GBA'" href="https://www.dkfz.de/en/verbis/" title="DKFZ" target="_blank">
         <img src="assets/img/german-cancer-research-center-dkfz-logo-vector.svg#svgView(viewBox(240, 180, 180, 300))" alt="DKFZ-LOGO" class="dkfz-logo"/>
       </a>
     </div>
@@ -34,7 +34,7 @@
 
     <div fxLayout="row" fxLayoutAlign="space-between start">
       <div fxFlex="1 0 0"></div>
-      <a href="https://www.bmbf.de/" title="BMBF" target="_blank">
+      <a *ngIf="featureService.brandingUI() === 'GBA'" href="https://www.bmbf.de/" title="BMBF" target="_blank">
         <img src="assets/img/BMBF_CMYK_Gef_L_e.svg#svgView(viewBox(295, 350, 1, 130))" alt="BMBF-LOGO" class="bmbf-logo"/>
       </a>
 


### PR DESCRIPTION
This a retry of the PR #115 with clean rebase on current develop.

[BIOB-227] Removal of footer from BBMRI Locator

Not displaying DKFZ and german .DE/ministry logos when branding is BBMRI